### PR TITLE
Update core.py

### DIFF
--- a/pyNetLogo/core.py
+++ b/pyNetLogo/core.py
@@ -466,7 +466,7 @@ class NetLogoLink(object):
             fn = r'{0}{1}{2}_{3}{4}'.format(os.getcwd(),
                                             os.sep,
                                             hash(self),
-                                            variable,
+                                            variable.replace('?', ''),
                                             '.txt')
             fns[variable] = fn
             fn = '"{}"'.format(fn)


### PR DESCRIPTION
When running the Segregation model on a Windows machine, pyNetLogo throws the following OSError when calling the `repeat_report()` function:

`OSError: [Errno 22] Invalid argument: '<file_path>\\119014232538_count turtles with [ not happy? ].txt'`

because the '?' character is a forbidden character and so the file cannot be created.

The proposed fix simply replaces any '?' characters with '' when building the `fn` string. It's possible other models include other forbidden characters and so the fix could be generalized, but I'm only familiar with this case.