### PR TITLE
More robust find_netlogo_mac()

### DIFF
--- a/pyNetLogo/core.py
+++ b/pyNetLogo/core.py
@@ -149,6 +149,8 @@ def find_netlogo_mac():
             netlogo = find_netlogo(path)
         except IndexError:
             pass
+        except OSError:
+            pass
         else:
             netlogo = os.path.join(path, netlogo)
 


### PR DESCRIPTION
`find_netlogo_mac()` looks in `/Applications/` and the full path of `~/Applications`. Unfortunately, some users do not have `~/Applications` (probably because they run a single Admin account for daily use and installing software). In such a case, line 149 of `core.py` runs into an issue with `find_netlogo(path)`, raising an _Errno 2_ file not found error.

Since `find_netlogo_mac()` already has `netlogo = None` by default, passing on this error should not introduce any new errors – if there is no NetLogo, then the function will return `None` (as is already the case).

I'm not sure what might happen if NetLogo is installed in both Application folders though. I don't even know if that is possible!