### PR TITLE
depricated .ix in patch_report changed for .loc

### DIFF
--- a/pyNetLogo/core.py
+++ b/pyNetLogo/core.py
@@ -434,7 +434,7 @@ class NetLogoLink(object):
                 resultsvec = self.link.report('map [p -> [{0}] of p] \
                                                sort patches'.format(attribute))    
             resultsvec = self._cast_results(resultsvec)
-            results_df.ix[:, :] = resultsvec.reshape(results_df.shape)
+            results_df.loc[:, :] = resultsvec.reshape(results_df.shape)
 
             return results_df
 


### PR DESCRIPTION
Since pandas 0.20.0, the .ix indexer is deprecated, in favor of the more strict .iloc and .loc indexers.