### PR TITLE
Bugfix: ticklocs -> locs

### DIFF
--- a/examples/SALib_ipyparallel.ipynb
+++ b/examples/SALib_ipyparallel.ipynb
@@ -818,7 +818,7 @@
     "    ax = fig.add_subplot(111, polar=True)\n",
     "    ax.grid(False)\n",
     "    ax.spines['polar'].set_visible(False)\n",
-    "    ax.set_xticks(ticklocs)\n",
+    "    ax.set_xticks(locs)\n",
     "\n",
     "    ax.set_xticklabels(names)\n",
     "    ax.set_yticklabels([])\n",


### PR DESCRIPTION
the number of locations was filtered by locs = ticklocs[0:-1], but the code proceeded to use ticklocs for the setting of xticks resulting in an error.