### PR TITLE
core.py: Add `jar_name` and `class_name` keys for NetLogo 6.3

### DIFF
--- a/pyNetLogo/core.py
+++ b/pyNetLogo/core.py
@@ -22,12 +22,14 @@ PYNETLOGO_HOME = os.path.dirname(os.path.abspath(__file__))
 jar_name = {'5': 'netlogolink53.jar',
             '6.0': 'netlogolink60.jar',
             '6.1': 'netlogolink61.jar',
-            '6.2': 'netlogolink61.jar'}
+            '6.2': 'netlogolink61.jar',
+            '6.3': 'netlogolink61.jar'}
 
 class_name = {'5': 'NetLogoLinkV5.NetLogoLink',
               '6.0': 'NetLogoLinkV6.NetLogoLink',
               '6.1': 'NetLogoLinkV61.NetLogoLink',
-              '6.2': 'NetLogoLinkV61.NetLogoLink'}
+              '6.2': 'NetLogoLinkV61.NetLogoLink',
+              '6.3': 'NetLogoLinkV61.NetLogoLink'}
 
 _logger = None
 LOGGER_NAME = "EMA"


### PR DESCRIPTION
This commit allows PyNetlogo to use NetLogo 6.3, by using the same `netlogolink61.jar` and `NetLogoLinkV61.NetLogoLink` that NetLogo 6.1 and 6.2 use.

So far not tested, so no idea if a new jar/link is needed or things need to be updated.

Part of #60.