### PR TITLE
core: Change deprecated np.float to float

### DIFF
--- a/pyNetLogo/core.py
+++ b/pyNetLogo/core.py
@@ -603,7 +603,7 @@ class NetLogoLink(object):
                     try:
                         # Try a numerical data type
                         result = np.array([np.array(e.split(),
-                                                    dtype=np.float) for e in
+                                                    dtype=float) for e in
                                            list_res])
                     except:
                         # Otherwise, assume the reporter returns string values


### PR DESCRIPTION
`np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe.

Deprecated in NumPy 1.20; for more details and guidance: [numpy.org/devdocs/release/1.20.0-notes.html#deprecations](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)